### PR TITLE
fix LinkageError messages when trying to call log() with an exception as argument

### DIFF
--- a/pepper-lib/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepper/cli/PepperStarter.java
+++ b/pepper-lib/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepper/cli/PepperStarter.java
@@ -17,6 +17,7 @@
  */
 package de.hu_berlin.german.korpling.saltnpepper.pepper.cli;
 
+import ch.qos.logback.classic.LoggerContext;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -1020,6 +1021,14 @@ public class PepperStarter {
 		PepperConnector pepper = null;
 		boolean endedWithErrors = false;
 
+		if(LoggerFactory.getILoggerFactory() instanceof LoggerContext) {
+			LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+			// in our OSGI environment package data extraction 
+			// results in strange errors when log() is called with an 
+			// exception as argument
+			lc.setPackagingDataEnabled(false);
+		}
+		
 		try {
 			PepperStarterConfiguration pepperProps = new PepperStarterConfiguration();
 			pepperProps.load();


### PR DESCRIPTION
Logback uses "packaging data" to display in which jar file in which version an element of the stacktrace comes from: http://logback.qos.ch/reasonsToSwitch.html#packagingData

Unfortunally this seems to produce problems in Pepper (or OSGI in general?) when one of the logging functions is called with a pepper Exception as argument (as in https://github.com/korpling/pepper/blob/develop/pepper-lib/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepper/cli/PepperStarter.java#L1101). This causes e.g. that errors when reading the pepper configuration file occur their are not properly reported but the linkage error comes instead.

It is planned to add a XML configuration parameter to logback in a later release (see https://github.com/qos-ch/logback/pull/248) since other users have performance problems with this feature. Until this is released  I would suggest to disable this feature in code, even if that means we have to use Logback specific code in PepperStarter.