### PR TITLE
PepperUtil#readXMLResource: Set error handler to content handler so clients can handle SAXExeptions

### DIFF
--- a/pepper-framework/src/main/java/org/corpus_tools/pepper/common/PepperUtil.java
+++ b/pepper-framework/src/main/java/org/corpus_tools/pepper/common/PepperUtil.java
@@ -216,7 +216,7 @@ public abstract class PepperUtil {
 				return (null);
 			}
 			char[] chrs = theString.toCharArray();
-			HashSet<Character> separators = new HashSet<Character>();
+			HashSet<Character> separators = new HashSet<>();
 			separators.add(' ');
 			separators.add('.');
 			separators.add(',');
@@ -595,18 +595,21 @@ public abstract class PepperUtil {
 	 *            location of the xml-file
 	 */
 	public static void readXMLResource(DefaultHandler2 contentHandler, URI documentLocation) {
-		if (documentLocation == null)
+		if (documentLocation == null) {
 			throw new PepperModuleXMLResourceException(
 					"Cannot load a xml-resource, because the given uri to locate file is null.");
+		}
 
 		File resourceFile = new File(documentLocation.toFileString());
-		if (!resourceFile.exists())
+		if (!resourceFile.exists()) {
 			throw new PepperModuleXMLResourceException(
 					"Cannot load a xml-resource, because the file does not exist: " + resourceFile);
+		}
 
-		if (!resourceFile.canRead())
+		if (!resourceFile.canRead()) {
 			throw new PepperModuleXMLResourceException(
 					"Cannot load a xml-resource, because the file can not be read: " + resourceFile);
+		}
 
 		SAXParser parser;
 		XMLReader xmlReader;
@@ -616,6 +619,7 @@ public abstract class PepperUtil {
 		try {
 			parser = factory.newSAXParser();
 			xmlReader = parser.getXMLReader();
+			xmlReader.setErrorHandler(contentHandler);
 			xmlReader.setContentHandler(contentHandler);
 		} catch (ParserConfigurationException e) {
 			throw new PepperModuleXMLResourceException(
@@ -634,6 +638,7 @@ public abstract class PepperUtil {
 			try {
 				parser = factory.newSAXParser();
 				xmlReader = parser.getXMLReader();
+				xmlReader.setErrorHandler(contentHandler);
 				xmlReader.setContentHandler(contentHandler);
 				xmlReader.parse(resourceFile.getAbsolutePath());
 			} catch (Exception e1) {


### PR DESCRIPTION
When the XML parser's XML reader's error handler remains unset (i.e., *as is*), clients have no way to catch exceptions thrown by the reader.

As [`PepperUtil#readXMLResource()`](https://github.com/korpling/pepper/blob/develop/pepper-framework/src/main/java/org/corpus_tools/pepper/common/PepperUtil.java#L597) takes an instance of `DefaultHandler2` as argument anyway, and this type defines methods for catching and throwing exceptions (via its supertype `DefaultHandler`'s `fatalError(SAXException e)`, `error(...)` and `warning(...)` methods), the reader's error handler can confidently be set to the `contentHandler` argument (i.e., *this change*), as this will simply fall back to the default implementation when clients don't override any of the methods in their implementation of `DefaultHandler2`.