### PR TITLE
Use a thread-safe hash set implementation for controller list and also make sure there is no reace condition when creating a new instance in getter function

### DIFF
--- a/pepper-framework/src/main/java/org/corpus_tools/pepper/core/ModuleControllerImpl.java
+++ b/pepper-framework/src/main/java/org/corpus_tools/pepper/core/ModuleControllerImpl.java
@@ -17,7 +17,10 @@
  */
 package org.corpus_tools.pepper.core;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -345,7 +348,7 @@ public class ModuleControllerImpl implements ModuleController {
 	 * This list is used to control, if this {@link ModuleControllerImpl} object
 	 * and its {@link PepperModule} work correctly.
 	 **/
-	private HashSet<DocumentController> controllList = null;
+	private final Set<DocumentController> controllList = Collections.newSetFromMap(new ConcurrentHashMap<DocumentController, Boolean>());
 
 	/**
 	 * This set contains all {@link DocumentController} objects which have been
@@ -357,13 +360,8 @@ public class ModuleControllerImpl implements ModuleController {
 	 * 
 	 * @return set of document controllers in progress
 	 */
-	private HashSet<DocumentController> getControllList() {
-		if (controllList == null) {
-			synchronized (this) {
-				controllList = new HashSet<DocumentController>();
-			}
-		}
-		return (controllList);
+	private Set<DocumentController> getControllList() {
+		return controllList;
 	}
 
 	/** {@inheritDoc ModuleController#next(boolean)} */


### PR DESCRIPTION
The original getter function checked for null first and then synchronized an only synchronized the access when a new instance was created. There was the possibility of race condition that an existing instance was overwritten by a new one when getControllerList() was called at the same time and the latter call would overwrite the original instance. This is solved by making the member variable final and creating the hash set on construction time of the ModuleControllerImpl.