### PR TITLE
Add ability to get default value for PepperModuleProperty

### DIFF
--- a/pepper-framework/src/main/java/org/corpus_tools/pepper/modules/PepperModuleProperty.java
+++ b/pepper-framework/src/main/java/org/corpus_tools/pepper/modules/PepperModuleProperty.java
@@ -38,7 +38,7 @@ import java.io.Serializable;
  */
 public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<?>>, Serializable {
 	private static final long serialVersionUID = -1577480488804525468L;
-	private T defaultValue;
+	private final T defaultValue;
 
 	/**
 	 * Creates a {@link PepperModuleProperty} instance and sets its values to
@@ -53,6 +53,7 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 		this.name = name;
 		this.clazz = clazz;
 		this.description = description;
+		this.defaultValue = null;
 	}
 
 	/**
@@ -67,7 +68,9 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 	 *            a default value for the value
 	 */
 	public PepperModuleProperty(final String name, Class<T> clazz, final String description, T defaultValue) {
-		this(name, clazz, description);
+		this.name = name;
+		this.clazz = clazz;
+		this.description = description;
 		this.value = defaultValue;
 		this.defaultValue = defaultValue;
 	}
@@ -108,7 +111,10 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 	 */
 	public PepperModuleProperty(final String name, Class<T> clazz, final String description, T defaultValue,
 			final boolean required) {
-		this(name, clazz, description, required);
+		this.name = name;
+		this.clazz = clazz;
+		this.description = description;
+		this.required = required;
 		this.value = defaultValue;
 		this.defaultValue = defaultValue;
 	}

--- a/pepper-framework/src/main/java/org/corpus_tools/pepper/modules/PepperModuleProperty.java
+++ b/pepper-framework/src/main/java/org/corpus_tools/pepper/modules/PepperModuleProperty.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
  */
 public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<?>>, Serializable {
 	private static final long serialVersionUID = -1577480488804525468L;
+	private T defaultValue;
 
 	/**
 	 * Creates a {@link PepperModuleProperty} instance and sets its values to
@@ -68,6 +69,7 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 	public PepperModuleProperty(final String name, Class<T> clazz, final String description, T defaultValue) {
 		this(name, clazz, description);
 		this.value = defaultValue;
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -108,6 +110,7 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 			final boolean required) {
 		this(name, clazz, description, required);
 		this.value = defaultValue;
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -250,6 +253,20 @@ public class PepperModuleProperty<T> implements Comparable<PepperModuleProperty<
 	 */
 	public T getValue() {
 		return (value);
+	}
+
+	/**
+	 * Returns the default value of this property,
+	 * as set via either of the two constructors
+	 * taking a default value as argument.
+	 * 
+	 * @see PepperModuleProperty#PepperModuleProperty(String, Class, String, Object)
+	 * @see PepperModuleProperty#PepperModuleProperty(String, Class, String, Object, boolean)
+	 * 
+	 * @return the defaultValue (final)
+	 */
+	public final T getDefaultValue() {
+		return defaultValue;
 	}
 
 	public String toString() {

--- a/pepper-framework/src/test/java/org/corpus_tools/pepper/modules/PepperModulePropertyTest.java
+++ b/pepper-framework/src/test/java/org/corpus_tools/pepper/modules/PepperModulePropertyTest.java
@@ -79,4 +79,21 @@ public class PepperModulePropertyTest extends TestCase {
 				defaultValue);
 		assertEquals(defaultValue, prop.getValue());
 	}
+	
+	/**
+	 * Tests the use of the default value, i.e.,
+	 * the actual default value field
+	 * PepperModuleProperty#defaultValue.
+	 */
+	@Test
+	public void testGetDefault() {
+		String defaultValue = "hello world";
+		PepperModuleProperty<String> prop = new PepperModuleProperty<String>("prop1", String.class, "desc",
+				defaultValue);
+		assertEquals(defaultValue, prop.getValue());
+		prop.setValue("goodbye world");
+		assertEquals("goodbye world", prop.getValue());
+		assertEquals("hello world", prop.getDefaultValue());
+	}
+
 }


### PR DESCRIPTION
- Add a field and a final getter for the default value of a PepperModuleProperty. Should return the value if a default has been set via a constructor, and null if it hasn't been set