### PR TITLE
Deploy a P2 site on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,27 @@
 language: java
+jdk:
+  - openjdk8
+  
+  
+before_script:
+  - export SHORT_VERSION=`echo ${TRAVIS_TAG:-develop} | sed -E 's/(\.[0-9]+)$//'` 
+  
+before_deploy:
+   - mvn p2:site
+
+deploy:
+  - provider: script
+    script: bash $TRAVIS_BUILD_DIR/misc/deploy-p2.sh
+    on:
+      repo: korpling/pepper
+      branch: master
+      tags: true
+      condition: $TRAVIS_OS_NAME = linux
+    skip-cleanup: true
+  - provider: script
+    script: bash $TRAVIS_BUILD_DIR/misc/deploy-p2.sh
+    on:
+      repo: korpling/pepper
+      branch: feature/p2-site
+      condition: $TRAVIS_OS_NAME = linux
+    skip-cleanup: true

--- a/misc/deploy-p2.sh
+++ b/misc/deploy-p2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Used by CI to deploy the existing target/repository/<version> directory to Github Pages
+
+if [ -n "$GITHUB_API_KEY" ]; then
+    cd "$TRAVIS_BUILD_DIR"
+
+    echo "cloning gh-pages from ${TRAVIS_REPO_SLUG}"
+    git clone -q  -b gh-pages https://$GITHUB_API_KEY@github.com/${TRAVIS_REPO_SLUG} gh-pages &>/dev/null
+    cd gh-pages
+    mkdir -p p2/${SHORT_VERSION}
+    cd p2/${SHORT_VERSION}
+    # remove all old file
+    rm -Rf *
+    # copy the P2 repository content from the maven build directory
+    cp -R ${TRAVIS_BUILD_DIR}/target/repository/* .
+    git add .
+    git -c user.name='travis' -c user.email='travis' commit -m "add p2 repository for version ${SHORT_VERSION}"
+    echo "pushing to gh-pages to ${TRAVIS_REPO_SLUG}"
+    git push -q https://$GITHUB_API_KEY@github.com/${TRAVIS_REPO_SLUG} gh-pages &>/dev/null
+    cd "$TRAVIS_BUILD_DIR"
+else
+	>&2 echo "Cannot deploy P2 repository because GITHUB_API_KEY environment variable is not set"
+	exit 1
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -462,6 +462,36 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 			</plugin>
+			<plugin>
+				<groupId>org.reficio</groupId>
+				<artifactId>p2-maven-plugin</artifactId>
+				<version>1.3.0</version>
+				<executions>
+					<execution>
+						<id>default-cli</id>
+						<configuration>
+							<artifacts>
+								<artifact>
+									<id>org.corpus-tools:pepper-lib:${project.version}</id>
+								</artifact>
+							</artifacts>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>9.3.27.v20190418</version>
+				<configuration>
+					<scanIntervalSeconds>10</scanIntervalSeconds>
+					<webAppSourceDirectory>${basedir}/target/repository/</webAppSourceDirectory>
+					<webApp>
+						<contextPath>/site</contextPath>
+					</webApp>
+				</configuration>
+			</plugin>
 		</plugins>
 		<finalName>${project.artifactId}-${project.version}</finalName>
 	</build>


### PR DESCRIPTION
Extend the CI configuration to create a version-specific P2 repository on GitHub pages. This allows us to more easily add Pepper as dependency to Eclipse RCP based applications as Hexatomic (hexatomic/hexatomic#15)